### PR TITLE
iter2: agent + tests

### DIFF
--- a/cmd/agent/collector/collector.go
+++ b/cmd/agent/collector/collector.go
@@ -1,0 +1,56 @@
+package collector
+
+import (
+	"math/rand/v2"
+	"runtime"
+
+	"github.com/and161185/metrics-alerting/model"
+)
+
+var pollCount int64
+
+func CollectRuntimeMetrics() []model.Metric {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+
+	pollCount++
+
+	res := []model.Metric{
+		{ID: "Alloc", Type: model.Gauge, Value: float64(m.Alloc)},
+		{ID: "BuckHashSys", Type: model.Gauge, Value: float64(m.BuckHashSys)},
+		{ID: "Frees", Type: model.Gauge, Value: float64(m.Frees)},
+		{ID: "GCCPUFraction", Type: model.Gauge, Value: m.GCCPUFraction},
+		{ID: "GCSys", Type: model.Gauge, Value: float64(m.GCSys)},
+		{ID: "HeapAlloc", Type: model.Gauge, Value: float64(m.HeapAlloc)},
+		{ID: "HeapIdle", Type: model.Gauge, Value: float64(m.HeapIdle)},
+		{ID: "HeapInuse", Type: model.Gauge, Value: float64(m.HeapInuse)},
+		{ID: "HeapObjects", Type: model.Gauge, Value: float64(m.HeapObjects)},
+		{ID: "HeapReleased", Type: model.Gauge, Value: float64(m.HeapReleased)},
+		{ID: "HeapSys", Type: model.Gauge, Value: float64(m.HeapSys)},
+		{ID: "LastGC", Type: model.Gauge, Value: float64(m.LastGC)},
+		{ID: "Lookups", Type: model.Gauge, Value: float64(m.Lookups)},
+		{ID: "MCacheInuse", Type: model.Gauge, Value: float64(m.MCacheInuse)},
+		{ID: "MCacheSys", Type: model.Gauge, Value: float64(m.MCacheSys)},
+		{ID: "MSpanInuse", Type: model.Gauge, Value: float64(m.MSpanInuse)},
+		{ID: "MSpanSys", Type: model.Gauge, Value: float64(m.MSpanSys)},
+		{ID: "Mallocs", Type: model.Gauge, Value: float64(m.Mallocs)},
+		{ID: "NextGC", Type: model.Gauge, Value: float64(m.NextGC)},
+		{ID: "NumForcedGC", Type: model.Gauge, Value: float64(m.NumForcedGC)},
+		{ID: "NumGC", Type: model.Gauge, Value: float64(m.NumGC)},
+		{ID: "OtherSys", Type: model.Gauge, Value: float64(m.OtherSys)},
+		{ID: "PauseTotalNs", Type: model.Gauge, Value: float64(m.PauseTotalNs)},
+		{ID: "StackInuse", Type: model.Gauge, Value: float64(m.StackInuse)},
+		{ID: "StackSys", Type: model.Gauge, Value: float64(m.StackSys)},
+		{ID: "Sys", Type: model.Gauge, Value: float64(m.Sys)},
+		{ID: "TotalAlloc", Type: model.Gauge, Value: float64(m.TotalAlloc)},
+
+		{ID: "PollCount", Type: model.Counter, Value: float64(pollCount)},
+		{ID: "RandomValue", Type: model.Gauge, Value: rand.Float64()},
+	}
+
+	return res
+}
+
+func ResetPollCount() {
+	pollCount = 0
+}

--- a/cmd/agent/collector/collector_test.go
+++ b/cmd/agent/collector/collector_test.go
@@ -1,0 +1,53 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/and161185/metrics-alerting/model"
+	"github.com/magiconair/properties/assert"
+)
+
+func TestCollectRuntimeMetrics(t *testing.T) {
+
+	requiredMetrics := map[string]bool{
+		"Alloc":       false,
+		"GCSys":       false,
+		"HeapAlloc":   false,
+		"PollCount":   false,
+		"RandomValue": false,
+	}
+
+	metrics := CollectRuntimeMetrics()
+
+	for _, v := range metrics {
+		if _, ok := requiredMetrics[v.ID]; ok {
+			requiredMetrics[v.ID] = true
+		}
+
+		if v.Type != model.Counter && v.Type != model.Gauge {
+			t.Errorf("invalid type: %s for metric %s", v.Type, v.ID)
+		}
+	}
+
+	for id, found := range requiredMetrics {
+		if !found {
+			t.Errorf("required metric %s not found", id)
+		}
+	}
+
+	poll1 := getMetricValue(metrics, "PollCount")
+
+	metrics2 := CollectRuntimeMetrics()
+	poll2 := getMetricValue(metrics2, "PollCount")
+
+	assert.Equal(t, poll1+1, poll2, "PollCount test failed")
+}
+
+func getMetricValue(metrics []model.Metric, id string) float64 {
+	for _, m := range metrics {
+		if m.ID == id {
+			return m.Value
+		}
+	}
+	return -1 // или panic если хочешь жёстче
+}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,3 +1,75 @@
 package main
 
-func main() {}
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/and161185/metrics-alerting/cmd/agent/collector"
+	"github.com/and161185/metrics-alerting/storage"
+)
+
+func main() {
+
+	serverAddr := "http://localhost:8080"
+
+	if err := run(serverAddr); err != nil {
+		panic(err)
+	}
+}
+
+func run(serverAddr string) error {
+	storage := storage.NewMemStorage()
+	tics := 0
+
+	for {
+		time.Sleep(1 * time.Second)
+		tics++
+
+		if tics%2 == 0 {
+			for _, m := range collector.CollectRuntimeMetrics() {
+				storage.Save(m)
+			}
+		}
+
+		if tics%10 == 0 {
+			if err := SendToServer(storage, serverAddr); err == nil {
+				collector.ResetPollCount()
+			}
+		}
+	}
+}
+
+func SendToServer(s *storage.MemStorage, serverAddr string) error {
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	for _, metric := range s.GetAll() {
+		url := fmt.Sprintf(
+			"%s/update/%s/%s/%v",
+			serverAddr,
+			metric.Type,
+			metric.ID,
+			metric.Value,
+		)
+
+		req, err := http.NewRequest(http.MethodPost, url, nil)
+		if err != nil {
+			return fmt.Errorf("creating request for %s: %w", metric.ID, err)
+		}
+		req.Header.Set("Content-Type", "text/plain")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("sending %s: %w", metric.ID, err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("unexpected status for %s: %d", metric.ID, resp.StatusCode)
+		}
+	}
+
+	return nil
+}

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/and161185/metrics-alerting/model"
+	"github.com/and161185/metrics-alerting/storage"
+)
+
+func TestSendToServer(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/update/") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s, want POST", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	st := storage.NewMemStorage()
+	st.Save(model.Metric{ID: "TestMetric", Type: model.Gauge, Value: 42.0})
+
+	err := SendToServer(st, ts.URL)
+	if err != nil {
+		t.Errorf("SendToServer failed: %v", err)
+	}
+}

--- a/cmd/server/handlers/update.go
+++ b/cmd/server/handlers/update.go
@@ -41,30 +41,30 @@ func UpdateMetricHandler(storage storage.Storage) http.HandlerFunc {
 	}
 }
 
-func getMetrics(urlPath string) (*model.Metric, error) {
+func getMetrics(urlPath string) (model.Metric, error) {
 
 	urlParts := strings.Split(urlPath, "/")
 	if len(urlParts) != 4 {
-		return nil, ErrInvalidUrl
+		return model.Metric{}, ErrInvalidUrl
 	}
 
 	metricsType := model.MetricType(urlParts[1])
 	if invalidMetricsType(metricsType) {
-		return nil, ErrInvalidType
+		return model.Metric{}, ErrInvalidType
 	}
 
 	metricsName := urlParts[2]
 	if invalidMetricsName(metricsName) {
-		return nil, ErrInvalidName
+		return model.Metric{}, ErrInvalidName
 	}
 
 	metricsValue, err := getMetricsValue(urlParts[3], metricsType)
 	if err != nil {
-		return nil, fmt.Errorf("invalid value: %w", err)
+		return model.Metric{}, fmt.Errorf("invalid value: %w", err)
 	}
 
 	result := model.Metric{ID: metricsName, Type: metricsType, Value: metricsValue}
-	return &result, nil
+	return result, nil
 }
 
 func invalidMetricsType(t model.MetricType) bool {

--- a/cmd/server/handlers/update_test.go
+++ b/cmd/server/handlers/update_test.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/and161185/metrics-alerting/storage"
+	"github.com/magiconair/properties/assert"
+)
+
+func TestUpdateMetricHandler(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		url        string
+		wantStatus int
+	}{
+		{"invalid method", http.MethodGet, "/update/gauge/test/1.23", http.StatusMethodNotAllowed},
+		{"valid gauge", http.MethodPost, "/update/gauge/test/1.23", http.StatusOK},
+		{"valid counter", http.MethodPost, "/update/counter/testCounter/1", http.StatusOK},
+		{"invalid counter value", http.MethodPost, "/update/counter/testCounter/1.2", http.StatusBadRequest},
+		{"invalid type", http.MethodPost, "/update/type/testCounter/1", http.StatusBadRequest},
+		{"invalid url", http.MethodPost, "/update/gauge/gauge", http.StatusNotFound},
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			st := storage.NewMemStorage()
+			handler := UpdateMetricHandler(st)
+
+			r := httptest.NewRequest(v.method, v.url, nil)
+			w := httptest.NewRecorder()
+
+			handler(w, r)
+
+			response := w.Result()
+
+			defer response.Body.Close()
+
+			assert.Equal(t, v.wantStatus, response.StatusCode)
+
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/and161185/metrics-alerting
 
 go 1.22.1
+
+require github.com/magiconair/properties v1.8.10

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
+github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=

--- a/storage/in-memory.go
+++ b/storage/in-memory.go
@@ -5,23 +5,33 @@ import (
 )
 
 type MemStorage struct {
-	metrics map[string]float64
+	metrics map[string]model.Metric
 }
 
 func NewMemStorage() *MemStorage {
 	return &MemStorage{
-		metrics: make(map[string]float64),
+		metrics: make(map[string]model.Metric),
 	}
 }
 
-func (s *MemStorage) Save(m *model.Metric) error {
+func (s *MemStorage) Save(m model.Metric) error {
 	_, ok := s.metrics[m.ID]
 	if !ok {
-		s.metrics[m.ID] = m.Value
+		s.metrics[m.ID] = m
 	} else if m.Type == model.Gauge {
-		s.metrics[m.ID] = m.Value
+		s.metrics[m.ID] = m
 	} else if m.Type == model.Counter {
-		s.metrics[m.ID] += m.Value
+		existing := s.metrics[m.ID]
+		existing.Value += m.Value
+		s.metrics[m.ID] = existing
 	}
 	return nil
+}
+
+func (s *MemStorage) GetAll() map[string]model.Metric {
+	result := make(map[string]model.Metric, len(s.metrics))
+	for k, v := range s.metrics {
+		result[k] = v
+	}
+	return result
 }

--- a/storage/in-memory_test.go
+++ b/storage/in-memory_test.go
@@ -1,0 +1,37 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/and161185/metrics-alerting/model"
+)
+
+func TestMemStorage(t *testing.T) {
+	st := NewMemStorage()
+
+	// gauge
+	g := model.Metric{ID: "TestGauge", Type: model.Gauge, Value: 42.0}
+	st.Save(g)
+
+	if got := st.GetAll()["TestGauge"].Value; got != 42.0 {
+		t.Errorf("Gauge save failed: got %v, want 42", got)
+	}
+
+	g2 := model.Metric{ID: "TestGauge", Type: model.Gauge, Value: 100.0}
+	st.Save(g2)
+
+	if got := st.GetAll()["TestGauge"].Value; got != 100.0 {
+		t.Errorf("Gauge overwrite failed: got %v, want 100", got)
+	}
+
+	// counter
+	c := model.Metric{ID: "TestCounter", Type: model.Counter, Value: 10}
+	st.Save(c)
+
+	c2 := model.Metric{ID: "TestCounter", Type: model.Counter, Value: 5}
+	st.Save(c2)
+
+	if got := st.GetAll()["TestCounter"].Value; got != 15.0 {
+		t.Errorf("Counter accumulate failed: got %v, want 15", got)
+	}
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3,6 +3,6 @@ package storage
 import "github.com/and161185/metrics-alerting/model"
 
 type Storage interface {
-	Save(metric *model.Metric) error
+	Save(metric model.Metric) error
 	//Get(id string) (*model.Metric, error)
 }


### PR DESCRIPTION
Создан агент.
Вынес логику коллектора в отдельный пакет для улучшения модульности и упрощения тестирования. Решил, что пока нет смысла выносить SendToServer из main.go.
Пришел к выводу, что в ин-мемори хранилище логичнее хранить всю структуру метрики, а не только айди и значение.
Т.к. структура метрики маленькая — передаю её по значению.