### PR TITLE
inc4: flags, client-server refactor

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,80 +1,15 @@
 package main
 
 import (
-	"fmt"
-	"io"
-	"net/http"
-	"time"
-
-	"github.com/and161185/metrics-alerting/cmd/agent/collector"
+	"github.com/and161185/metrics-alerting/internal/client"
 	"github.com/and161185/metrics-alerting/storage"
 )
 
 func main() {
 
-	serverAddr := "http://localhost:8080"
+	c := client.NewClient(storage.NewMemStorage())
 
-	if err := run(serverAddr); err != nil {
+	if err := c.Run(); err != nil {
 		panic(err)
 	}
-}
-
-func run(serverAddr string) error {
-	storage := storage.NewMemStorage()
-	tics := 0
-
-	for {
-		time.Sleep(1 * time.Second)
-		tics++
-
-		if tics%2 == 0 {
-			for _, m := range collector.CollectRuntimeMetrics() {
-				storage.Save(m)
-			}
-		}
-
-		if tics%10 == 0 {
-			if err := SendToServer(storage, serverAddr); err == nil {
-				collector.ResetPollCount()
-			}
-		}
-	}
-}
-
-func SendToServer(s *storage.MemStorage, serverAddr string) error {
-	client := &http.Client{Timeout: 2 * time.Second}
-
-	all, err := s.GetAll()
-	if err != nil {
-		return fmt.Errorf("internal error: %w", err)
-	}
-
-	for _, metric := range all {
-		url := fmt.Sprintf(
-			"%s/update/%s/%s/%v",
-			serverAddr,
-			metric.Type,
-			metric.ID,
-			metric.Value,
-		)
-
-		req, err := http.NewRequest(http.MethodPost, url, nil)
-		if err != nil {
-			return fmt.Errorf("creating request for %s: %w", metric.ID, err)
-		}
-		req.Header.Set("Content-Type", "text/plain")
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return fmt.Errorf("sending %s: %w", metric.ID, err)
-		}
-		io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("unexpected status for %s: %d", metric.ID, resp.StatusCode)
-		}
-	}
-
-	return nil
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,30 +1,14 @@
 package main
 
 import (
-	"net/http"
-
+	"github.com/and161185/metrics-alerting/internal/server"
 	"github.com/and161185/metrics-alerting/storage"
-
-	"github.com/go-chi/chi/middleware"
-	"github.com/go-chi/chi/v5"
 )
 
 func main() {
 
-	if err := run(); err != nil {
+	s := server.NewServer(storage.NewMemStorage())
+	if err := s.Run(); err != nil {
 		panic(err)
 	}
-}
-
-func run() error {
-
-	server := Server{storage: storage.NewMemStorage()}
-
-	router := chi.NewRouter()
-	router.Use(middleware.StripSlashes)
-	router.Post("/update/{type}/{name}/{value}", server.UpdateMetricHandler)
-	router.Get("/value/{type}/{name}", server.GetMetricHandler)
-	router.Get("/", server.ListMetricsHandler)
-
-	return http.ListenAndServe(":8080", router)
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,126 @@
+package client
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/and161185/metrics-alerting/cmd/agent/collector"
+	"github.com/and161185/metrics-alerting/storage"
+)
+
+type Client struct {
+	storage    storage.Storage
+	config     *Config
+	httpClient *http.Client
+}
+
+type Config struct {
+	serverAddr     string
+	reportInterval int
+	pollInterval   int
+	clientTimeout  int
+}
+
+func NewClient(storage storage.Storage) *Client {
+
+	config := NewConfig()
+
+	return &Client{
+		storage:    storage,
+		config:     config,
+		httpClient: &http.Client{Timeout: time.Duration(config.clientTimeout) * time.Second},
+	}
+}
+
+func NewConfig() *Config {
+	cfg := &Config{}
+	flag.StringVar(&cfg.serverAddr, "a", "http://localhost:8080", "HTTP server address (must include http(s)://)")
+	flag.IntVar(&cfg.reportInterval, "r", 10, "report interval")
+	flag.IntVar(&cfg.pollInterval, "p", 2, "poll interval")
+	flag.IntVar(&cfg.clientTimeout, "t", 10, "client timeout")
+	flag.Parse()
+
+	if !strings.HasPrefix(cfg.serverAddr, "http://") && !strings.HasPrefix(cfg.serverAddr, "https://") {
+		cfg.serverAddr = "http://" + cfg.serverAddr
+	}
+
+	return cfg
+}
+
+func (c *Client) Run() error {
+
+	store := c.storage
+	pollInterval := c.config.pollInterval
+	reportInterval := c.config.reportInterval
+
+	tics := 0
+
+	for {
+		time.Sleep(1 * time.Second)
+		tics++
+
+		fmt.Println("Tick:", tics)
+
+		if tics%pollInterval == 0 {
+			for _, m := range collector.CollectRuntimeMetrics() {
+				store.Save(m)
+			}
+		}
+
+		if tics%reportInterval == 0 {
+			if err := c.SendToServer(); err == nil {
+				fmt.Println("SendToServer success")
+
+				collector.ResetPollCount()
+			} else {
+				fmt.Println("SendToServer error:", err)
+
+			}
+		}
+	}
+}
+
+func (c *Client) SendToServer() error {
+
+	store := c.storage
+	serverAddr := c.config.serverAddr
+	httpClient := c.httpClient
+
+	all, err := store.GetAll()
+	if err != nil {
+		return fmt.Errorf("internal error: %w", err)
+	}
+
+	for _, metric := range all {
+		url := fmt.Sprintf(
+			"%s/update/%s/%s/%v",
+			serverAddr,
+			metric.Type,
+			metric.ID,
+			metric.Value,
+		)
+
+		req, err := http.NewRequest(http.MethodPost, url, nil)
+		if err != nil {
+			return fmt.Errorf("creating request for %s: %w", metric.ID, err)
+		}
+		req.Header.Set("Content-Type", "text/plain")
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("sending %s: %w", metric.ID, err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("unexpected status for %s: %d", metric.ID, resp.StatusCode)
+		}
+	}
+
+	return nil
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,10 +1,11 @@
-package main
+package client
 
 import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/and161185/metrics-alerting/model"
 	"github.com/and161185/metrics-alerting/storage"
@@ -25,7 +26,13 @@ func TestSendToServer(t *testing.T) {
 	st := storage.NewMemStorage()
 	st.Save(model.Metric{ID: "TestMetric", Type: model.Gauge, Value: 42.0})
 
-	err := SendToServer(st, ts.URL)
+	client := &Client{
+		storage:    st,
+		config:     &Config{serverAddr: ts.URL},
+		httpClient: &http.Client{Timeout: 2 * time.Second},
+	}
+
+	err := client.SendToServer()
 	if err != nil {
 		t.Errorf("SendToServer failed: %v", err)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,4 +1,4 @@
-package main
+package server
 
 import (
 	"io"


### PR DESCRIPTION
Поскольку у клиента и сервера появились настраиваемые свойства, потребовалось создать структуры для их хранения.
Логичным продолжением стало добавление методов к этим структурам.
Для удобства и логического разделения кода сервер и клиент были вынесены в отдельные пакеты.